### PR TITLE
Fix button wrapping in main links

### DIFF
--- a/src/components/MainLinks/MainLink.tsx
+++ b/src/components/MainLinks/MainLink.tsx
@@ -16,11 +16,11 @@ const MainLink = ({ icon, label, pathName }: LinkProps) => {
       <UnstyledButton
         className={
           location.pathname === pathName
-            ? 'bg-emerald-100 w-full h-10 p-2 rounded-md'
-            : 'bg-zinc-50 w-full h-10 p-2 rounded-md'
+            ? 'bg-emerald-100 w-full h-10 p-2 rounded-md whitespace-nowrap'
+            : 'bg-zinc-50 w-full h-10 p-2 rounded-md whitespace-nowrap'
         }
       >
-        <Group className='justify-start '>
+        <Group className='justify-start flex-nowrap'>
           {icon}
           <Text size='sm'>{label}</Text>
         </Group>


### PR DESCRIPTION
## Description

<!-- *Please include a summary of the change and which issue number is fixed (e.g. Fixes #1). Please also include relevant motivation and context.* -->
Button wrapping for mainlinks would cause the text to break onto a new line on screen resizing, causing text to be clipped.
Added flex and whitespace nowraps to force button content to stick to a single line.

## How has this been tested?

<!-- *Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.* -->
Tested changes locally to confirm that responsiveness is restored

## Screenshots

<!-- *Provide screenshots of what has been implemented. Leave blank if not applicable* -->

## Checklist

<!-- *(Leave blank if not applicable)* -->

- [x] I have performed a self-review of my own code
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass
