### PR TITLE
🔧 Fix notification area clickthrough

### DIFF
--- a/src/components/AppNotifications/AppNotifications.tsx
+++ b/src/components/AppNotifications/AppNotifications.tsx
@@ -38,7 +38,7 @@ const AppNotifications = () => {
       type='hover'
       className={
         (notifications || []).length > 0
-          ? '!fixed right-0 top-0 mt-4 mb-4 pb-8 ml-8 mr-4 pr-4 max-w-md h-full'
+          ? '!fixed right-0 top-0 mt-4 mb-4 pb-8 ml-8 mr-4 pr-4 max-w-md h-full pointer-events-none'
           : 'hidden'
       }
       style={{ zIndex: 110 }}
@@ -49,7 +49,7 @@ const AppNotifications = () => {
             icon={getNotificationIcon(notification)}
             title={getNotificationTitle(notification)}
             color={getNotificationColour(notification)}
-            className='bg-white/30 backdrop-blur-md'
+            className='bg-white/30 backdrop-blur-md pointer-events-auto'
             classNames={{ title: 'text-lg' }}
             onClose={() => removeNotification!(notification)}
             // eslint-disable-next-line react/no-array-index-key


### PR DESCRIPTION
## Description

Allows the user to click-through the notifications scroll area (previously having a notification up would cause the entire column to be unclickable).

Closes #58

## How has this been tested?

Locally.

## Screenshots

## Checklist

<!-- *(Leave blank if not applicable)* -->

- [x] I have performed a self-review of my own code
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass
