### PR TITLE
🛑 Stop highlight tooltips from overflowing

### DIFF
--- a/src/components/ProblemText/ProblemText.tsx
+++ b/src/components/ProblemText/ProblemText.tsx
@@ -36,7 +36,6 @@ const ProblemText = ({
     const parentLeft = boundingRect?.left ?? 0;
     tooltip.forEach((t) => {
       // Calculate the left offset based on whether the tooltip is inside a relative parent
-      // console.log();
       const maxWidth =
         e.clientX - parentLeft + t.offsetWidth / 2 - (boundingRect?.width ?? 0);
       const minWidth = e.clientX - parentLeft - t.offsetWidth / 2;

--- a/src/components/ProblemText/ProblemText.tsx
+++ b/src/components/ProblemText/ProblemText.tsx
@@ -23,23 +23,36 @@ const ProblemText = ({
     document.querySelectorAll<HTMLElement>('.tooltiptext')
   );
 
+  const textRef = React.useRef<HTMLDivElement>(null);
+
   const stickyTooltip = (e: React.MouseEvent) => {
     const relativeParent = relativeParentId
       ? document.getElementById(relativeParentId)
       : undefined;
+    const boundingRect = relativeParent
+      ? relativeParent?.getBoundingClientRect()
+      : textRef.current?.getBoundingClientRect();
+    const parentTop = boundingRect?.top ?? 0;
+    const parentLeft = boundingRect?.left ?? 0;
     tooltip.forEach((t) => {
+      // Calculate the left offset based on whether the tooltip is inside a relative parent
+      // console.log();
+      const maxWidth =
+        e.clientX - parentLeft + t.offsetWidth / 2 - (boundingRect?.width ?? 0);
+      const minWidth = e.clientX - parentLeft - t.offsetWidth / 2;
+      const leftOffset = maxWidth > 0 ? maxWidth : 0;
+      const rightOffset = minWidth < 0 ? minWidth : 0;
+      const xOffset =
+        t.offsetWidth / 2 +
+        leftOffset +
+        rightOffset +
+        (relativeParent ? parentLeft : 0);
+      const yOffset = (tooltipOffset ?? 50) + (relativeParent ? parentTop : 0);
+
       // eslint-disable-next-line no-param-reassign
-      t.style.top = `${
-        e.clientY -
-        (relativeParent?.getBoundingClientRect().top ?? 0) -
-        (tooltipOffset ?? 50)
-      }px`;
+      t.style.top = `${e.clientY - yOffset}px`;
       // eslint-disable-next-line no-param-reassign
-      t.style.left = `${
-        e.clientX -
-        (relativeParent?.getBoundingClientRect().left ?? 0) -
-        t.offsetWidth / 2
-      }px`;
+      t.style.left = `${e.clientX - xOffset}px`;
     });
   };
 
@@ -52,6 +65,7 @@ const ProblemText = ({
       className={`${className} ${textClassNames} text-justify`}
       onMouseUp={onMouseUp}
       onMouseMove={(e: React.MouseEvent) => stickyTooltip(e)}
+      ref={textRef}
     >
       <TypographyStylesProvider className={providerClassNames}>
         {HTMLReactParser(getProblemStatement!())}

--- a/src/index.css
+++ b/src/index.css
@@ -32,17 +32,6 @@
   z-index: 1;
 }
 
-.tooltip .tooltiptext::after {
-  content: "";
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  margin-left: -5px;
-  border-width: 5px;
-  border-style: solid;
-  border-color: black transparent transparent transparent;
-}
-
 .tooltip:hover {
   border-bottom: 1px dotted black;
 }


### PR DESCRIPTION
## Description

Highlight tooltips should now not go over the containing element's edge in the x axis.

## How has this been tested?

Locally

## Checklist

<!-- *(Leave blank if not applicable)* -->

- [x] I have performed a self-review of my own code
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass
