### PR TITLE
🔥 HOTFIX: Set maximum width for parsons fragments

### DIFF
--- a/src/pages/EvaluationPage/EvaluationPage.tsx
+++ b/src/pages/EvaluationPage/EvaluationPage.tsx
@@ -61,7 +61,7 @@ const EvaluationPage = () => {
           />
         </Group>
         <Group className='items-start pb-32 flex-nowrap bg-gray-100 shadow-inner mx-4 rounded-lg'>
-          <Stack spacing={0} className='grow min-h-[32rem]'>
+          <Stack spacing={0} className='grow min-h-[32rem] max-w-[50%]'>
             <Title order={4} className='text-center py-4 '>
               Drag from here
             </Title>
@@ -88,7 +88,7 @@ const EvaluationPage = () => {
               ))}
             </ReactSortable>
           </Stack>
-          <Stack spacing={0} className='grow min-h-[32rem]'>
+          <Stack spacing={0} className='grow min-h-[32rem] max-w-[50%]'>
             <Title order={4} className='py-4 text-center'>
               Design your solution here
             </Title>

--- a/src/pages/EvaluationPage/EvaluationPage.tsx
+++ b/src/pages/EvaluationPage/EvaluationPage.tsx
@@ -61,7 +61,7 @@ const EvaluationPage = () => {
           />
         </Group>
         <Group className='items-start pb-32 flex-nowrap bg-gray-100 shadow-inner mx-4 rounded-lg'>
-          <Stack spacing={0} className='grow min-h-[32rem] max-w-[50%]'>
+          <Stack spacing={0} className='grow min-h-[32rem] w-[50%]'>
             <Title order={4} className='text-center py-4 '>
               Drag from here
             </Title>
@@ -88,7 +88,7 @@ const EvaluationPage = () => {
               ))}
             </ReactSortable>
           </Stack>
-          <Stack spacing={0} className='grow min-h-[32rem] max-w-[50%]'>
+          <Stack spacing={0} className='grow min-h-[32rem] w-[50%]'>
             <Title order={4} className='py-4 text-center'>
               Design your solution here
             </Title>


### PR DESCRIPTION
## Description

Prevent parsons fragments from getting too long

## How has this been tested?

Locally

## Checklist

<!-- *(Leave blank if not applicable)* -->

- [x] I have performed a self-review of my own code
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass
