### PR TITLE
:rocket: Add ability to disable action plan tab

### DIFF
--- a/src/components/BottomPanel/BottomPanel.tsx
+++ b/src/components/BottomPanel/BottomPanel.tsx
@@ -1,23 +1,35 @@
 import { Stack, Tabs } from '@mantine/core';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { HiOutlinePlay } from 'react-icons/hi';
 import { IoRocketOutline } from 'react-icons/io5';
+import useInterventions from '../../hooks/useInterventions';
 import ActionPlan from '../ActionPlan';
 import CodeRunArea from '../CodeRunArea';
 
 const BottomPanel = () => {
   const [currentTabIndex, setCurrentTabIndex] = React.useState(0);
+  const { interventions } = useInterventions();
+  const [actionPlanTabEnabled, setActionPlanTabEnabled] = useState(true);
+
+  useEffect(() => {
+    const evaluatingASolutionEnabled = interventions.find(
+      ({ name }) => name === 'Evaluating a solution'
+    )?.enabled;
+    setActionPlanTabEnabled(evaluatingASolutionEnabled ?? false);
+  }, [interventions]);
 
   return (
     <Stack className='p-4 pt-0 relative'>
       <Tabs active={currentTabIndex} onTabChange={setCurrentTabIndex}>
-        <Tabs.Tab
-          label='Action Plan'
-          key={0}
-          icon={<IoRocketOutline size={20} />}
-        >
-          <ActionPlan />
-        </Tabs.Tab>
+        {actionPlanTabEnabled && (
+          <Tabs.Tab
+            label='Action Plan'
+            key={0}
+            icon={<IoRocketOutline size={20} />}
+          >
+            <ActionPlan />
+          </Tabs.Tab>
+        )}
         <Tabs.Tab label='Run Code' key={1} icon={<HiOutlinePlay size={20} />}>
           <CodeRunArea />
         </Tabs.Tab>


### PR DESCRIPTION
## Description

<!-- *Please include a summary of the change and which issue number is fixed (e.g. Fixes #1). Please also include relevant motivation and context.* -->
Adds functionality to disable to action plan tab on the  "Implementing a solution" page when the "Evaluating a solution" intervention is disabled.
Closes #99 

## How has this been tested?

<!-- *Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.* -->
Disable "evaluating a solution" in firebase console, then check that tab is not visible on the "implementing a solution" page.

## Screenshots

<!-- *Provide screenshots of what has been implemented. Leave blank if not applicable* -->

## Checklist

<!-- *(Leave blank if not applicable)* -->

- [x] I have performed a self-review of my own code
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass
