### PR TITLE
🚚 Semi fix the action list

### DIFF
--- a/src/pages/EvaluationPage/EditFragmentCard.tsx
+++ b/src/pages/EvaluationPage/EditFragmentCard.tsx
@@ -23,12 +23,7 @@ const EditFragmentCard = ({
   handleCancelAction: () => void;
 }) => (
   <>
-    <Card
-      shadow='sm'
-      radius='md'
-      p='md'
-      className='bg-white cursor-grab h-fit min-w-0'
-    >
+    <Card shadow='sm' radius='md' p='md' className='bg-white h-fit min-w-0'>
       <Group position='apart'>
         <TextInput
           value={editAction.action}

--- a/src/pages/EvaluationPage/EvaluationPage.tsx
+++ b/src/pages/EvaluationPage/EvaluationPage.tsx
@@ -145,7 +145,9 @@ const EvaluationPage = () => {
                 My Actions
               </Title>
               <ReactSortable
-                list={getUnusedListItems!()}
+                list={getUnusedListItems!().concat(
+                  editAction && isNewAction ? [editAction] : []
+                )}
                 setList={setUnusedListItems}
                 group='design-parsons'
                 animation={100}

--- a/src/pages/EvaluationPage/NewFragmentCard.tsx
+++ b/src/pages/EvaluationPage/NewFragmentCard.tsx
@@ -14,12 +14,7 @@ const NewFragmentCard = ({
   handleCancelAction: () => void;
 }) => (
   <>
-    <Card
-      shadow='sm'
-      radius='md'
-      p='md'
-      className='bg-white cursor-grab h-fit min-w-0'
-    >
+    <Card shadow='sm' radius='md' p='md' className='bg-white h-fit min-w-0'>
       <TextInput
         value={editAction.action}
         onChange={(e) =>


### PR DESCRIPTION
## Description

* Dragging around actions in the edit state should no longer break everything
* Dragging around NEWly created actions in the edit state should cause the new action to immediately snap back into place at the bottom of the unused list
* Dragging around EXISTING actions in the edit state should work fine
* I've changed the cursor to no longer be grab when in the edit state to discourage students from trying to grab items in the edit state

## How has this been tested?

Relatively thoroughly, and locally. Doesn't seem to break anything.

## Screenshots

<!-- *Provide screenshots of what has been implemented. Leave blank if not applicable* -->

## Checklist

<!-- *(Leave blank if not applicable)* -->

- [x] I have performed a self-review of my own code
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass
