### PR TITLE
🥷 Remove button focus after click

### DIFF
--- a/src/components/generics/GenericButton/GenericButton.tsx
+++ b/src/components/generics/GenericButton/GenericButton.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { Button, MantineSize } from '@mantine/core';
+import { MantineSize, Button } from '@mantine/core';
+import { MouseEvent, ReactNode } from 'react';
 
 type GenericButtonProps = {
   text: string;
   onClick?: () => void;
   className?: string;
-  leftIcon?: React.ReactNode;
+  leftIcon?: ReactNode;
   type?: 'button' | 'submit' | 'reset' | undefined;
   size?: MantineSize;
   disabled?: boolean;
@@ -32,11 +32,17 @@ const GenericButton = ({
   } else if (blue) {
     myClassName = `w-fit bg-blue-500 fill-blue-50 hover:bg-blue-600 rounded-md ${className}`;
   }
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.currentTarget?.blur();
+    if (onClick) onClick();
+  };
+
   return (
     <Button
       uppercase
       size={size}
-      onClick={onClick}
+      onClick={handleClick}
       className={myClassName}
       leftIcon={leftIcon}
       type={type}


### PR DESCRIPTION
## Description

Currently it's possible for the tooltip on the submit button to persist almost indefinitely in certain circumstances.
This means that users are unable to access key elements in the UI, such as other buttons, and their code's output.

This is a well-known bug and appears to be fixed in newer versions of Mantine.
@uoa-ypec413 found a workaround by calling `blur()` on the target of the click mouse event. This effectively forces the browser to unfocus on the button after a click.

Seems to work very well, and should resolve a number of complaints in the user feedback.

## How has this been tested?

<!-- *Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.* -->

## Screenshots

<!-- *Provide screenshots of what has been implemented. Leave blank if not applicable* -->

## Checklist

<!-- *(Leave blank if not applicable)* -->

- [x] I have performed a self-review of my own code
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass
